### PR TITLE
[TASK] Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
         "mikey179/vfsStream": "~1.3.0",
         "satooshi/php-coveralls": "*"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.1.x-dev"
+        }
+    },
     "bin": [
         "bin/setversion",
         "bin/upload",


### PR DESCRIPTION
Branch aliases are useful for other to be able to require the alias
instead of dev-master, which can lead into trouble with breaking changes.
