### PR TITLE
[TASK] Make comment argument mandatory

### DIFF
--- a/bin/upload
+++ b/bin/upload
@@ -10,13 +10,11 @@ foreach ($paths as $path) {
 				require $path;
 		}
 }
-
-if (3 > count($argv)) {
-	die('Upload command requires a total of at least three arguments in the following order: directory username password (comment)' . PHP_EOL);
+if (5 > count($argv)) {
+	die('Upload command requires a total of four arguments in the following order: directory username password comment' . PHP_EOL);
 }
 
-list (, $directory, $username, $password) = $argv;
-$comment = TRUE === isset($argv[4]) ? $argv[4] : NULL;
+list (, $directory, $username, $password, $comment) = $argv;
 
 $uploader = new \NamelessCoder\TYPO3RepositoryClient\Uploader();
 $directory = realpath($directory);

--- a/src/Uploader.php
+++ b/src/Uploader.php
@@ -13,7 +13,7 @@ class Uploader {
 	 * @param string $comment
 	 * @return array
 	 */
-	public function upload($directory, $username, $password, $comment = NULL) {
+	public function upload($directory, $username, $password, $comment) {
 		return $this->getConnection()->call(
 			Connection::FUNCTION_UPLOAD,
 			$this->getExtensionUploadPacker()->pack($directory, $username, $password, $comment),


### PR DESCRIPTION
The comment argument isn't optional anymore when
uploading through SOAP interface.

- Make all arguments mandatory
- Adopt error message

Fixes: #16