### PR TITLE
[BUGFIX] Fix warning in PHP 7.4

### DIFF
--- a/src/ExtensionUploadPacker.php
+++ b/src/ExtensionUploadPacker.php
@@ -271,7 +271,7 @@ class ExtensionUploadPacker {
 	 * @return boolean
 	 */
 	protected function isDotFileAndNotPermitted($filename) {
-		return (FALSE === empty($filename) && '.' === $filename{0} && FALSE === in_array($filename, $this->permittedDotFiles));
+		return (FALSE === empty($filename) && '.' === $filename[0] && FALSE === in_array($filename, $this->permittedDotFiles));
 	}
 
 }


### PR DESCRIPTION
Array and string offset access syntax with curly braces is deprecated