### PR TITLE
[FEATURE] Use symfony var exporter for PSR-2 code export

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - "7"
   - "7.1"
 
 before_install: composer self-update

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,11 @@
         }
     },
     "require": {
-        "php": "^7.0"
+        "php": "^7.1",
+        "symfony/var-exporter": "^4.2"
     },
     "require-dev": {
-        "mikey179/vfsStream": "~1.3.0",
+        "mikey179/vfsstream": "~1.3.0",
         "satooshi/php-coveralls": "*",
         "phpunit/phpunit": "^6.0"
     },
@@ -37,6 +38,9 @@
         "bin/rmversion"
     ],
     "config": {
-        "bin-dir": "bin"
+        "bin-dir": "bin",
+        "platform": {
+            "php": "7.1.99"
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,84 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47788f33a6fba18e46e800ebf92e3a97",
-    "packages": [],
+    "content-hash": "306a128212703059f96781af300a459e",
+    "packages": [
+        {
+            "name": "symfony/var-exporter",
+            "version": "v4.4.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "a07f9c350ebe30dadd30505d2b05d7c9bbcef2b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/a07f9c350ebe30dadd30505d2b05d7c9bbcef2b1",
+                "reference": "a07f9c350ebe30dadd30505d2b05d7c9bbcef2b1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3"
+            },
+            "require-dev": {
+                "symfony/var-dumper": "^4.4.9|^5.0.9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A blend of var_export() + serialize() to turn any serializable data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v4.4.16"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T11:50:19+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
@@ -1955,5 +2028,9 @@
     "platform": {
         "php": "^7.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.1.99"
+    },
+    "plugin-api-version": "2.0.0"
 }

--- a/src/Versioner.php
+++ b/src/Versioner.php
@@ -1,6 +1,8 @@
 <?php
 namespace NamelessCoder\TYPO3RepositoryClient;
 
+use Symfony\Component\VarExporter\VarExporter;
+
 /**
  * Class Versioner
  */
@@ -128,7 +130,7 @@ class Versioner
         $configuration = $this->readExtensionConfigurationFile($filename);
         $configuration[self::PARAMETER_VERSION] = $version;
         $configuration[self::PARAMETER_STABILITY] = $stability;
-        $contents = '<' . '?php' . PHP_EOL . '$EM_CONF[$_EXTKEY] = ' . var_export($configuration, true) . ';' . PHP_EOL;
+        $contents = '<' . '?php' . PHP_EOL . '$EM_CONF[$_EXTKEY] = ' . VarExporter::export($configuration) . ';' . PHP_EOL;
         return file_put_contents($filename, $contents);
     }
 }

--- a/tests/unit/VersionerTest.php
+++ b/tests/unit/VersionerTest.php
@@ -7,6 +7,7 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamFile;
 use org\bovigo\vfs\vfsStreamWrapper;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarExporter\VarExporter;
 
 /**
  * Class VersionerTest
@@ -57,7 +58,7 @@ class VersionerTest extends TestCase
     public static function setUpBeforeClass()
     {
         self::$fixtureString =
-            '<' . '?php' . PHP_EOL . '$EM_CONF[$_EXTKEY] = ' . var_export(self::$fixture, true) . ';' . PHP_EOL;
+            '<' . '?php' . PHP_EOL . '$EM_CONF[$_EXTKEY] = ' . VarExporter::export(self::$fixture) . ';' . PHP_EOL;
         $emConf = new vfsStreamFile(Versioner::FILENAME_EXTENSION_CONFIGURATION);
         $emConf->setContent(self::$fixtureString);
 
@@ -352,7 +353,7 @@ class VersionerTest extends TestCase
         $fixture['version'] = $version;
         $fixture['state'] = $stability;
 
-        $expectedData = '<' . '?php' . PHP_EOL . '$EM_CONF[$_EXTKEY] = ' . var_export($fixture, true) . ';' . PHP_EOL;
+        $expectedData = '<' . '?php' . PHP_EOL . '$EM_CONF[$_EXTKEY] = ' . VarExporter::export($fixture) . ';' . PHP_EOL;
 
         $versioner = new Versioner();
 


### PR DESCRIPTION
This is a breaking change as it doesn't work with PHP 7.0. Minimum PHP version is PHP 7.1